### PR TITLE
Use Stirling's approximation to expand range of Poisson pmf

### DIFF
--- a/Distr/distr.pp
+++ b/Distr/distr.pp
@@ -1025,29 +1025,161 @@ poisson distribution. pmf: f(x;l) = e^(-l) * l^x / x!
 );
 
 pp_def('pmf_poisson',
+  Pars      => 'x(); l(); float+ [o]p()',
+  GenericTypes => [F,D],
+  HandleBad => 1,
+  Code      => q{
+
+  if ($x() < 0) {
+    $p() = 0;
+  }
+  else if ($x() < GSL_SF_FACT_NMAX / 2) {
+    /* Exact formula */
+    $p() = exp( -1 * $l()) * pow($l(),$x()) / gsl_sf_fact( (unsigned int) $x() );
+  }
+  else {
+    /* Use Stirling's approximation. See
+     * http://en.wikipedia.org/wiki/Stirling%27s_approximation
+     */
+    double log_p = $x() - $l() + $x() * log($l() / $x())
+      - 0.5 * log(2*M_PI * $x()) - 1. / 12. / $x()
+      + 1 / 360. / $x()/$x()/$x() - 1. / 1260. / $x()/$x()/$x()/$x()/$x();
+    $p() = exp(log_p);
+  }
+
+  },
+  BadCode   => q{
+
+  if ( $ISBAD($x()) || $ISBAD($l()) ) {
+    $SETBAD( $p() );
+  }
+  else {
+    if ($x() < 0) {
+      $p() = 0;
+    }
+    else if ($x() < GSL_SF_FACT_NMAX / 2) {
+      /* Exact formula */
+      $p() = exp( -1 * $l()) * pow($l(),$x()) / gsl_sf_fact( (unsigned int) $x() );
+    }
+    else {
+      /* Use Stirling's approximation. See
+       * http://en.wikipedia.org/wiki/Stirling%27s_approximation
+       */
+      double log_p = $x() - $l() + $x() * log($l() / $x())
+        - 0.5 * log(2*M_PI * $x()) - 1. / 12. / $x()
+        + 1 / 360. / $x()/$x()/$x() - 1. / 1260. / $x()/$x()/$x()/$x()/$x();
+      $p() = exp(log_p);
+    }
+  }
+
+  },
+  Doc      => q{
+
+=for ref
+
+probability mass function for poisson distribution. Uses Stirling's formula
+for large values of the input
+
+=cut
+
+  },
+
+);
+
+pp_def('pmf_poisson_stirling',
+  Pars      => 'x(); l(); [o]p()',
+  GenericTypes => [F,D],
+  HandleBad => 1,
+  Code      => q{
+
+  if ($x() < 0) {
+    $p() = 0;
+  }
+  else if ($x() == 0) {
+    $p() = exp(-$l());
+  }
+  else {
+    /* Use Stirling's approximation. See
+     * http://en.wikipedia.org/wiki/Stirling%27s_approximation
+     */
+    double log_p = $x() - $l() + $x() * log($l() / $x())
+      - 0.5 * log(2*M_PI * $x()) - 1. / 12. / $x()
+      + 1 / 360. / $x()/$x()/$x() - 1. / 1260. / $x()/$x()/$x()/$x()/$x();
+    $p() = exp(log_p);
+  }
+
+  },
+  BadCode   => q{
+
+  if ( $ISBAD($x()) || $ISBAD($l()) ) {
+    $SETBAD( $p() );
+  }
+  else if ($x() < 0) {
+    $p() = 0;
+  }
+  else if ($x() == 0) {
+    $p() = exp(-$l());
+  }
+  else {
+    /* Use Stirling's approximation. See
+     * http://en.wikipedia.org/wiki/Stirling%27s_approximation
+     */
+    double log_p = $x() - $l() + $x() * log($l() / $x())
+      - 0.5 * log(2*M_PI * $x()) - 1. / 12. / $x()
+      + 1 / 360. / $x()/$x()/$x() - 1. / 1260. / $x()/$x()/$x()/$x()/$x();
+    $p() = exp(log_p);
+  }
+
+  },
+  Doc      => q{
+
+=for ref
+
+probability mass function for poisson distribution. Uses Stirling's formula
+for all values of the input, 
+
+=cut
+
+  },
+
+);
+
+pp_def('pmf_poisson_factorial',
   Pars      => 'ushort x(); l(); float+ [o]p()',
   GenericTypes => [F,D],
   HandleBad => 1,
-  Code      => '
+  Code      => q{
 
-  $p() = exp( -1 * $l()) * pow($l(),$x()) / gsl_sf_fact( $x() );
+  if ($x() < GSL_SF_FACT_NMAX) {
+    $p() = exp( -1 * $l()) * pow($l(),$x()) / gsl_sf_fact( $x() );
+  }
+  else {
+    /* bail out */
+    $p() = 0;
+  }
 
-  ',
-  BadCode   => '
+  },
+  BadCode   => q{
 
-if ( $ISBAD($x()) || $ISBAD($l()) ) {
-  $SETBAD( $p() );
-}
-else {
-  $p() = exp( -1 * $l()) * pow($l(),$x()) / gsl_sf_fact( $x() );
-}
+  if ( $ISBAD($x()) || $ISBAD($l()) ) {
+    $SETBAD( $p() );
+  }
+  else {
+    if ($x() < GSL_SF_FACT_NMAX) {
+      $p() = exp( -1 * $l()) * pow($l(),$x()) / gsl_sf_fact( $x() );
+    }
+    else {
+      $p() = 0;
+    }
+  }
 
-  ',
+  },
   Doc      => '
 
 =for ref
 
-probability mass function for poisson distribution.
+probability mass function for poisson distribution. Input is limited to
+x < 170.
 
 =cut
 


### PR DESCRIPTION
The Poisson distribution is well behaved for large input values,
but the factorial form is not numerically stable and has a hard-coded
limit for its input values. Using Stirling's Approximation for the
logarithm of the factorial, we can rewrite the probability as a
sum of the logarithm of its terms, which is numerically stable.

This commit includes two new Poisson distribution functions as well
as modifications to the current distribution function. The factorial
form is called pmf_poisson_factorial and is a slight variant on the
original code that sets all probabilities for large input x to zero.
Perhaps a value of -1 would be better. The Stirling form is called
pmf_poisson_stirling and uses Stirling's approximation for all
values of x. This leads to numerically inaccurate results for very
small values of the input argument (though the inaccuracy is minor).
The Combined form is called pmf_poisson and uses the factorial form
for small values of x (roughly < 85) and the Stirling form for large
values of x.

Results from the Stirling and factorial forms differ, but that
difference falls within numerical bit noise for x roughly at
50.

This commit does not include tests. It is intended to demonstrate
the different forms. If accepted, tests should be fairly easy and
should follow shortly.
