### PR TITLE
Improved support for 64bit indexing

### DIFF
--- a/Basic/stats_basic.pd
+++ b/Basic/stats_basic.pd
@@ -53,7 +53,7 @@ pp_def('stdv',
   Code      => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -63,7 +63,7 @@ pp_def('stdv',
   BadCode  => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
 	sa += $a();
@@ -96,7 +96,7 @@ pp_def('stdv_unbiased',
   Code      => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -106,7 +106,7 @@ pp_def('stdv_unbiased',
   BadCode  => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
 	sa += $a();
@@ -139,7 +139,7 @@ pp_def('var',
   Code      => '
     $GENERIC(b) a2, sa;
     a2 = 0; sa = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       a2 += pow($a(), 2);
       sa += $a();
@@ -149,7 +149,7 @@ pp_def('var',
   BadCode  => '
     $GENERIC(b) a2, sa;
     a2 = 0; sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         a2 += pow($a(), 2);
@@ -182,7 +182,7 @@ pp_def('var_unbiased',
   Code      => '
     $GENERIC(b) a2, sa;
     a2 = 0; sa = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       a2 += pow($a(), 2);
       sa += $a();
@@ -192,7 +192,7 @@ pp_def('var_unbiased',
   BadCode  => '
     $GENERIC(b) a2, sa;
     a2 = 0; sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         a2 += pow($a(), 2);
@@ -225,7 +225,7 @@ pp_def('se',
   Code      => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -235,7 +235,7 @@ pp_def('se',
   BadCode  => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
 	sa += $a();
@@ -276,7 +276,7 @@ pp_def('ss',
   Code      => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -286,7 +286,7 @@ pp_def('ss',
   BadCode  => '
     $GENERIC(b) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
 	sa += $a();
@@ -319,7 +319,7 @@ pp_def('skew',
   Code      => '
     $GENERIC(b) sa, m, d, d2, d3;
     sa = 0; d2 = 0; d3 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -334,7 +334,7 @@ pp_def('skew',
   BadCode  => '
     $GENERIC(b) sa, m, d, d2, d3;
     sa = 0; m = 0; d=0; d2 = 0; d3 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -374,7 +374,7 @@ pp_def('skew_unbiased',
   Code      => '
     $GENERIC(b) sa, m, d, d2, d3;
     sa = 0; d2 = 0; d3 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -389,7 +389,7 @@ pp_def('skew_unbiased',
   BadCode  => '
     $GENERIC(b) sa, m, d, d2, d3;
     sa = 0; m = 0; d=0; d2 = 0; d3 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -429,7 +429,7 @@ pp_def('kurt',
   Code      => '
     $GENERIC(b) sa, m, d, d2, d4;
     sa = 0; d2 = 0; d4 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -444,7 +444,7 @@ pp_def('kurt',
   BadCode  => '
     $GENERIC(b) sa, m, d, d2, d4;
     sa = 0; m = 0; d=0; d2 = 0; d4 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -484,7 +484,7 @@ pp_def('kurt_unbiased',
   Code      => '
     $GENERIC(b) sa, m, d, d2, d4;
     sa = 0; d2 = 0; d4 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -499,7 +499,7 @@ pp_def('kurt_unbiased',
   BadCode  => '
     $GENERIC(b) sa, m, d, d2, d4;
     sa = 0; m = 0; d=0; d2 = 0; d4 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -540,7 +540,7 @@ pp_def('cov',
   Code      => '
     $GENERIC(c) ab, sa, sb;
     ab = 0; sa = 0; sb = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       ab += $a() * $b();
       sa += $a();
@@ -551,7 +551,7 @@ pp_def('cov',
   BadCode  => '
     $GENERIC(c) ab, sa, sb;
     ab = 0; sa = 0; sb = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISBAD($a()) || $ISBAD($b()) ) { }
       else {
@@ -584,13 +584,13 @@ pp_def('cov_table',
   HandleBad => 1,
   Code      => '
 
-long N, M;
+PDL_Indx N, M;
 N = $SIZE(n); M = $SIZE(m);
 $GENERIC(a) a_, b_;
 $GENERIC(c) ab, sa, sb, cov;
 
 if (N > 1 ) {
-  long i, j;
+  PDL_Indx i, j;
   for (i=0; i<M; i++) {
     for (j=i; j<M; j++) {
       ab = 0; sa = 0; sb = 0;
@@ -617,7 +617,7 @@ else {
 if ($SIZE(n) >= 2 ) {
   $GENERIC(a) a_, b_;
   $GENERIC(c) ab, sa, sb, cov;
-  long N, M, i, j;
+  PDL_Indx N, M, i, j;
   M = $SIZE(m);
   for (i=0; i<M; i++) {
     for (j=i; j<M; j++) {
@@ -701,7 +701,7 @@ pp_def('corr',
   Code      => '
     $GENERIC(c) ab, sa, sb, a2, b2, cov, va, vb;
     ab=0; sa=0; sb=0; a2=0; b2=0; cov=0; va=0; vb=0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     if (N > 1 ) {
       loop (n) %{
 	ab += $a() * $b();
@@ -723,7 +723,7 @@ pp_def('corr',
   BadCode  => '
     $GENERIC(c) ab, sa, sb, a2, b2, cov, va, vb;
     ab=0; sa=0; sb=0; a2=0; b2=0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISBAD($a()) || $ISBAD($b()) ) { }
       else {
@@ -783,13 +783,13 @@ pp_def('corr_table',
   HandleBad => 1,
   Code      => '
 
-long N, M;
+PDL_Indx N, M;
 N = $SIZE(n); M = $SIZE(m);
 $GENERIC(a) a_, b_;
 $GENERIC(c) ab, sa, sb, a2, b2, cov, va, vb, r;
 
 if (N > 1 ) {
-  long i, j;
+  PDL_Indx i, j;
   for (i=0; i<M; i++) {
     for (j=i+1; j<M; j++) {
       ab = 0; sa = 0; sb = 0; a2 = 0; b2 = 0;
@@ -822,7 +822,7 @@ else {
 if ($SIZE(n) >= 2 ) {
   $GENERIC(a) a_, b_;
   $GENERIC(c) ab, sa, sb, a2, b2, cov, va, vb, r;
-  long N, M, i, j;
+  PDL_Indx N, M, i, j;
   M = $SIZE(m);
   for (i=0; i<M; i++) {
     for (j=i+1; j<M; j++) {
@@ -951,14 +951,14 @@ t significance test for Pearson correlations.
 );
 
 pp_def('n_pair',
-  Pars      => 'a(n); b(n); int [o]c()',
-  GenericTypes => [L],
+  Pars      => 'a(n); b(n); indx [o]c()',
+  GenericTypes => [qw/L Q/],
   HandleBad => 1,
   Code      => '
     $c() = $SIZE(n);
   ',
   BadCode   => '
-    long N = 0;
+    PDL_Indx N = 0;
     loop(n) %{
       if ( $ISBAD($a()) || $ISBAD($b()) ) { }
       else {
@@ -985,7 +985,7 @@ pp_def('corr_dev',
   Code      => '
     $GENERIC(c) ab, a2, b2, cov, va, vb;
     ab = 0; a2 = 0; b2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     if (N > 1) {
       loop (n) %{
 	ab += $a() * $b();
@@ -1004,7 +1004,7 @@ pp_def('corr_dev',
   BadCode   => '
     $GENERIC(c) ab, a2, b2, cov, va, vb;
     ab = 0; a2 = 0; b2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISBAD($a()) || $ISBAD($b()) ) { }
       else {

--- a/Distr/distr.pd
+++ b/Distr/distr.pd
@@ -75,7 +75,7 @@ pp_def('mme_beta',
   Code      => '
     $GENERIC(alpha) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -88,7 +88,7 @@ pp_def('mme_beta',
   BadCode   => '
     $GENERIC(alpha) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -172,7 +172,7 @@ pp_def('mme_binomial',
   Code      => '
     $GENERIC(p) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -186,7 +186,7 @@ pp_def('mme_binomial',
   BadCode   => '
     $GENERIC(p) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -260,7 +260,7 @@ pp_def('mle_exp',
   HandleBad => 1,
   Code      => '
     $GENERIC(l) sa = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -268,7 +268,7 @@ pp_def('mle_exp',
   ',
   BadCode   => '
     $GENERIC(l) sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -332,7 +332,7 @@ pp_def('mme_gamma',
   Code      => '
     $GENERIC(shape) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -345,7 +345,7 @@ pp_def('mme_gamma',
   BadCode   => '
     $GENERIC(shape) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -420,7 +420,7 @@ pp_def('mle_gaussian',
   Code      => '
     $GENERIC(m) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -431,7 +431,7 @@ pp_def('mle_gaussian',
   BadCode   => '
     $GENERIC(m) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -503,7 +503,7 @@ pp_def('mle_geo',
   HandleBad => 1,
   Code      => '
     $GENERIC(p) sa = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -511,7 +511,7 @@ pp_def('mle_geo',
   ',
   BadCode   => '
     $GENERIC(p) sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -570,7 +570,7 @@ pp_def('mle_geosh',
   HandleBad => 1,
   Code      => '
     $GENERIC(p) sa = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -578,7 +578,7 @@ pp_def('mle_geosh',
   ',
   BadCode   => '
     $GENERIC(p) sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -647,7 +647,7 @@ pp_def('mle_lognormal',
   Code      => '
     $GENERIC(m) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += log($a());
     %}
@@ -660,7 +660,7 @@ pp_def('mle_lognormal',
   BadCode   => '
     $GENERIC(m) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
         sa += log($a());
@@ -705,7 +705,7 @@ pp_def('mme_lognormal',
   Code      => '
     $GENERIC(m) sa, a2;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -716,7 +716,7 @@ pp_def('mme_lognormal',
   BadCode   => '
     $GENERIC(m) sa, a2;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -800,7 +800,7 @@ pp_def('mme_nbd',
   Code      => '
     $GENERIC(p) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(), 2);
@@ -813,7 +813,7 @@ pp_def('mme_nbd',
   BadCode   => '
     $GENERIC(p) sa, a2, m, v;
     sa = 0; a2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
 	sa += $a();
@@ -891,7 +891,7 @@ pp_def('mme_pareto',
   Code      => '
     $GENERIC(xm) sa, min;
     sa = 0; min = $a(n=>0);
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       if (min > $a())
@@ -908,7 +908,7 @@ pp_def('mme_pareto',
   BadCode   => '
     $GENERIC(xm) sa, min;
     sa = 0; min = $a(n=>0);
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -989,7 +989,7 @@ pp_def('mle_poisson',
   Code      => '
     $GENERIC(l) sa;
     sa = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -998,7 +998,7 @@ pp_def('mle_poisson',
   BadCode   => '
     $GENERIC(l) sa;
     sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();

--- a/GLM/glm.pd
+++ b/GLM/glm.pd
@@ -82,7 +82,7 @@ pp_def('fill_m',
   BadCode   => '
     $GENERIC(b) sa, m;
     sa = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -148,7 +148,7 @@ pp_def('fill_rand',
   ',
   BadCode   => '
     $GENERIC(a) *g[ $SIZE(n) ];
-    long i, j;
+    PDL_Indx i, j;
     i = 0;
     srand( time( NULL ) );
     loop (n) %{
@@ -161,7 +161,8 @@ pp_def('fill_rand',
         $b() = $a();
       }
       else {
-        j = (long) ((i-1) * (double)(rand()) / (double)(RAND_MAX) + .5);
+        /* XXX-FIXME works on 64bit, but rand() is quite limited */
+        j = (PDL_Indx) ((i-1) * (double)(rand()) / (double)(RAND_MAX) + .5);
         $b() = *g[j];
       }
     %}
@@ -213,7 +214,7 @@ pp_def('dev_m',
   Code      => '
     $GENERIC(b) sa, m;
     sa = 0; m = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
     %}
@@ -225,7 +226,7 @@ pp_def('dev_m',
   BadCode   => '
     $GENERIC(b) sa, m;
     sa = 0; m = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -262,7 +263,7 @@ pp_def('stddz',
   Code      => '
     $GENERIC(b) sa, a2, m, sd;
     sa = 0; a2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       sa += $a();
       a2 += pow($a(),2);
@@ -276,7 +277,7 @@ pp_def('stddz',
   BadCode   => '
     $GENERIC(b) sa, a2, m, sd;
     sa = 0; a2 = 0; m = 0; sd = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISGOOD($a()) ) {
         sa += $a();
@@ -360,7 +361,7 @@ pp_def('mse',
   ',
   BadCode  => '
     $GENERIC(c) ss = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISBAD($a()) || $ISBAD($b()) ) { }
       else {
@@ -391,7 +392,7 @@ pp_def('rmse',
   Code      => '
     $GENERIC(c) d2;
     d2 = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       d2 += pow($a() - $b(), 2);
     %}
@@ -400,7 +401,7 @@ pp_def('rmse',
   BadCode  => '
     $GENERIC(c) d2;
     d2 = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ( $ISBAD($a()) || $ISBAD($b()) ) { }
       else {
@@ -439,7 +440,7 @@ pp_def('pred_logistic',
   BadCode  => '
     loop (n) %{
       $GENERIC(c) l = 0;
-      long bad = 0;
+      PDL_Indx bad = 0;
       loop (m) %{
         if ( $ISBAD($a()) || $ISBAD($b()) ) {
           bad = 1;
@@ -477,7 +478,7 @@ pp_def('d0',
   Code      => '
     $GENERIC(c) p, ll;
     p = 0; ll = 0;
-    long N = $SIZE(n);
+    PDL_Indx N = $SIZE(n);
     loop (n) %{
       p += $a();
     %}
@@ -490,7 +491,7 @@ pp_def('d0',
   BadCode  => '
     $GENERIC(c) p, ll;
     p = 0; ll = 0;
-    long N = 0;
+    PDL_Indx N = 0;
     loop (n) %{
       if ($ISGOOD( $a() )) {
         p += $a();

--- a/Kmeans/kmeans.pd
+++ b/Kmeans/kmeans.pd
@@ -115,11 +115,11 @@ pp_def('_random_cluster',
 if ($SIZE(c) > $SIZE(o))
   barf("more cluster than obs!");
 /* threading w time only srand produces identical clusters */
-int r;
+long r;
 srand( time( NULL ) + r++);
-int nc = $SIZE(c);
+PDL_Indx nc = $SIZE(c);
 loop (o) %{
-  int cl = rand() % nc;
+  PDL_Indx cl = rand() % nc; /* XXX-FIXME rand() is not 64bit friendly here! */
   loop (c) %{
     $b() = (c == cl)? 1 : 0;
   %}
@@ -132,12 +132,12 @@ loop (o) %{
 );
 
 pp_def('which_cluster',
-  Pars  => 'short a(o,c); int [o]b(o)',
+  Pars  => 'short a(o,c); indx [o]b(o)',
   GenericTypes => [U,L],
   HandleBad    => 1,
   Code  => '
 
-int cl;
+PDL_Indx cl;
 
 loop(o) %{
   cl=-1;
@@ -154,7 +154,7 @@ loop(o) %{
 
   BadCode  => '
 
-int cl;
+PDL_Indx cl;
 
 loop(o) %{
   cl=-1;
@@ -205,7 +205,7 @@ pp_def('assign',
   Code  => '
 
 $GENERIC(centroid) ssc, ssmin;
-int cl = 0;
+PDL_Indx cl = 0;
 
 loop (o) %{
   ssmin = -1;
@@ -229,7 +229,7 @@ loop (o) %{
   BadCode  => '
 
 $GENERIC(centroid) ssc, ssmin;
-long cl, nvc;
+PDL_Indx cl, nvc;
 cl = 0;
 
 loop (o) %{
@@ -313,7 +313,7 @@ pp_def('centroid',
   HandleBad => 1,
   Code  => '
 $GENERIC(m) s[ $SIZE(c) ][ $SIZE(v) ], s2[ $SIZE(c) ][ $SIZE(v) ];
-long n[ $SIZE(c) ];
+PDL_Indx n[ $SIZE(c) ];
 
 loop (c) %{
   loop (v) %{
@@ -349,7 +349,7 @@ loop (c) %{
   ',
   BadCode  => '
 $GENERIC(m) s[ $SIZE(c) ][ $SIZE(v) ], s2[ $SIZE(c) ][ $SIZE(v) ];
-long n[ $SIZE(c) ][ $SIZE(v) ];
+PDL_Indx n[ $SIZE(c) ][ $SIZE(v) ];
 
 loop (c) %{
   loop (v) %{

--- a/TS/ts.pd
+++ b/TS/ts.pd
@@ -54,13 +54,13 @@ pp_addhdr('
 
 pp_def('_acf',
   Pars  => 'x(t); [o]r(h)',
-  OtherPars => 'int lag=>h',
+  OtherPars => 'IV lag=>h',
   GenericTypes => [F,D],
   Code  => '
 
 $GENERIC(x) s, s2, m, cov0, covh;
 s=0; s2=0; m=0; cov0=0; covh=0;
-long T, i;
+PDL_Indx  T, i;
 T = $SIZE(t);
 
 loop(t) %{
@@ -88,7 +88,7 @@ loop (h) %{
 
 pp_def('_acvf',
   Pars  => 'x(t); [o]v(h)',
-  OtherPars => 'int lag=>h;',
+  OtherPars => 'IV lag=>h;',
   GenericTypes => [F,D],
   Code  => '
 
@@ -195,7 +195,7 @@ EOD
 pp_def('diff',
   Pars  => 'x(t); [o]dx(t)',
   Inplace   => 1,
-  GenericTypes => [U,L,F,D],
+  GenericTypes => [U,L,Q,F,D],
   Code  => '
 
 long tr;
@@ -225,7 +225,7 @@ Differencing. DX(t) = X(t) - X(t-1), DX(0) = X(0). Can be done inplace.
 pp_def('inte',
   Pars  => 'x(n); [o]ix(n)',
   Inplace   => 1,
-  GenericTypes => [F,D],
+  GenericTypes => [L,Q,F,D],
   Code  => '
 
 $GENERIC(x) tmp;
@@ -249,12 +249,12 @@ Integration. Opposite of differencing. IX(t) = X(t) + X(t-1), IX(0) = X(0). Can 
 
 
 pp_def('dseason',
-  Pars  => 'x(t); int d(); [o]xd(t)',
+  Pars  => 'x(t); indx d(); [o]xd(t)',
   GenericTypes => [F,D],
   HandleBad    => 1,
   Code  => '
 $GENERIC(x) xc, sum;
-int i, q, max;
+PDL_Indx i, q, max;
 q = ($d() % 2)? ($d() - 1) / 2 : $d() / 2;
 max = $SIZE(t) - 1;
 
@@ -287,7 +287,7 @@ else {
   ',
   BadCode  => '
 $GENERIC(x) sum;
-int i, q, min, max, ti, dd;
+PDL_Indx i, q, min, max, ti, dd;
 min = -1; max = -1;
 q = ($d() % 2)? ($d() - 1) / 2 : $d() / 2;
 
@@ -405,7 +405,7 @@ sub PDL::fill_ma {
 EOD
 
 pp_def('_fill_ma',
-  Pars  => 'x(t); int q(); [o]xf(t)',
+  Pars  => 'x(t); indx q(); [o]xf(t)',
   GenericTypes => [F,D],
   HandleBad    => 1,
   Code     => '
@@ -416,7 +416,7 @@ loop(t) %{
   ',
   BadCode  => '
 $GENERIC(x) sum, xx;
-int i, n, max;
+PDL_Indx i, n, max;
 max = $SIZE(t) - 1;
 loop(t) %{
   if ($ISBAD(x())) {
@@ -478,11 +478,11 @@ Filter, exponential smoothing. xf(t) = a * x(t) + (1-a) * xf(t-1)
 );
 
 pp_def('filter_ma',
-  Pars  => 'x(t); int q(); [o]xf(t)',
+  Pars  => 'x(t); indx q(); [o]xf(t)',
   GenericTypes => [F,D],
   Code  => '
 $GENERIC(x) sum;
-int i, n, max;
+PDL_Indx i, n, max;
 n = 2 * $q() + 1;
 max = $SIZE(t) - 1;
 loop(t) %{
@@ -515,7 +515,7 @@ pp_def('mae',
 
 $GENERIC(c) sum;
 sum = 0;
-int N = $SIZE(n);
+PDL_Indx N = $SIZE(n);
 loop(n) %{
   sum += fabs( $a() - $b() );
 %}
@@ -526,7 +526,7 @@ $c() = sum / N;
 
 $GENERIC(c) sum;
 sum = 0;
-int N = 0;
+PDL_Indx N = 0;
 loop(n) %{
   if ($ISBAD(a()) || $ISBAD(b())) { }
   else {
@@ -567,7 +567,7 @@ pp_def('mape',
 
 $GENERIC(c) sum;
 sum = 0;
-int N = $SIZE(n);
+PDL_Indx N = $SIZE(n);
 loop(n) %{
   sum += fabs( ($a() - $b()) / $a() );
 %}
@@ -579,7 +579,7 @@ $c() = sum / N;
 
 $GENERIC(c) sum;
 sum = 0;
-int N = 0;
+PDL_Indx N = 0;
 loop(n) %{
   if ($ISBAD(a()) || $ISBAD(b())) { }
   else {
@@ -769,11 +769,11 @@ EOD
 
 pp_def('_pred_ar',
   Pars  => 'x(p); b(p); [o]pred(t)',
-  OtherPars => 'int end=>t;',
+  OtherPars => 'IV end=>t;',
   GenericTypes => [F,D],
   Code  => '
 
-int ord = $SIZE(p);
+PDL_Indx ord = $SIZE(p);
 $GENERIC(x) xt, xp[ord];
 
 loop (t) %{


### PR DESCRIPTION
This patch tries to replace `int` or `long` where `PDL_Indx` is more appropriate. I have not tested it much with `>2GB` piddles.

Other thing worth mentioning is the use o C function `rand()` which usually returns far less bits than 64 - it is used in `glm.pd` and `kmeans.pd`. I have not tried to fix this trouble.