### PR TITLE
test demo-ing RT#107326 problem

### DIFF
--- a/GSL/t/cdf.t
+++ b/GSL/t/cdf.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More;
 
 BEGIN {
-    plan tests => 90;
+    plan tests => 93;
 }
 
 use PDL::LiteF;
@@ -118,3 +118,8 @@ sub tapprox {
   ok(all(approx(gsl_cdf_hypergeometric_P     ($z, 25, 5, 11), pdl([ 0.00324196875921016, 0.0472401162056337, 0.24523177971454, 0.61921603300914, 0.918403435644814 ]))));
   ok(all(approx(gsl_cdf_hypergeometric_Q     ($z, 25, 5, 11), pdl([ 0.99675803124079, 0.952759883794366, 0.75476822028546, 0.38078396699086, 0.0815965643551856 ]))));
 }
+
+# ensure gsl_cdf_hypergeometric_P fails with error with negative first value
+ok all approx(gsl_cdf_hypergeometric_P(0, 2, 8, 6), 0.133333333);
+ok all approx(gsl_cdf_hypergeometric_P(18, 2, 8, 6), 1);
+ok all approx(gsl_cdf_hypergeometric_P(-1, 2, 8, 6), 0);


### PR DESCRIPTION
This demonstrates the issue. It does not fix it (yet). This is quite complex as while the GSL function has an unsigned parameter, the PDL code is probably just silently casting the negative number to a large positive one. I don't know enough now about the PDL framework to constrain inputs as would be needed here.
