### PR TITLE
Fix spelling errors.

### DIFF
--- a/Kmeans/kmeans.pd
+++ b/Kmeans/kmeans.pd
@@ -786,7 +786,7 @@ sub PDL::iv_cluster {
 
 =head2 pca_cluster
 
-Assgin variables to components ie clusters based on pca loadings or scores. One way to seed kmeans (see Ding & He, 2004, and Su & Dy, 2004 for other ways of using pca with kmeans). Variables are assigned to their most associated component. Note that some components may not have any variable that is most associated with them, so the returned number of clusters may be smaller than NCOMP.
+Assign variables to components ie clusters based on pca loadings or scores. One way to seed kmeans (see Ding & He, 2004, and Su & Dy, 2004 for other ways of using pca with kmeans). Variables are assigned to their most associated component. Note that some components may not have any variable that is most associated with them, so the returned number of clusters may be smaller than NCOMP.
 
 Default options (case insensitive):
 

--- a/Stats.pm
+++ b/Stats.pm
@@ -14,7 +14,7 @@ $PDL::onlinedoc->scan(__FILE__) if $PDL::onlinedoc;
 
 Loads modules named below, making the functions available in the current namespace.
 
-Properly formated documentations online at http://pdl-stats.sf.net
+Properly formatted documentations online at http://pdl-stats.sf.net
  
 =head1 SYNOPSIS
 


### PR DESCRIPTION
- formated -> formatted
- Assgin   -> Assign

These spelling errors were reported by the lintian QA tool as part of the Debian package build.
